### PR TITLE
Use time.perf_counter if possible to measure time periods

### DIFF
--- a/thespian/test/test_timing.py
+++ b/thespian/test/test_timing.py
@@ -1,0 +1,14 @@
+import time
+
+from thespian import system
+
+
+def test_expiration_timer():
+    timer = system.ExpirationTimer(duration=1.0)
+    time.sleep(0.2)
+    assert timer.expired() == False
+    assert 0.7 <= timer.remainingSeconds() <= 0.9
+    time.sleep(1.0)
+    assert timer.expired() == True
+    assert timer.remainingSeconds() == 0.0
+


### PR DESCRIPTION
With this commit we will use `time.perf_counter()` if available
to measure time periods. On older Python versions we will
fall back to `time.time()`.

Previously, `datetime.datetime.now()` has been used which
resulted in lots of system calls opening the system timezone
file. With this implementation we'll avoid that.

Note that callsites have not been changed yet and we only
adapted `ExpirationTimer` / `ExpiryTime` to use the new
implementation.