### PR TITLE
Replace datetime.now() with ExpirationTimer

### DIFF
--- a/thespian/system/messages/status.py
+++ b/thespian/system/messages/status.py
@@ -98,10 +98,10 @@ def _common_formatStatus(tofd, response, childActorTag, showAddress=str):
     for F,T,M in response.receivedMessages:
         tofd.write('    %s <-- %s:  %s\n'%(showAddress(T), showAddress(F), M))
     tofd.write('  |Pending Wakeups [%d]:\n'%len(response.pendingWakeups))
-    import datetime
+    from thespian.system.timing import ExpirationTimer
     for W in response.pendingWakeups:
         tofd.write('    %s%s\n'%(str(W),
-                                 (' (in %s)'%(W - datetime.datetime.now()) if isinstance(W, datetime.datetime)
+                                 (' (in %s)'%W.remaining() if isinstance(W, ExpirationTimer)
                                   else '')))
     tofd.write('  |Pending Address Resolution [%d]:\n'%(len(response._pendingAddrCnts)))
     for A in response._pendingAddrCnts:

--- a/thespian/system/ratelimit.py
+++ b/thespian/system/ratelimit.py
@@ -1,6 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from time import sleep as delay
-from thespian.system.timing import timePeriodSeconds
+from thespian.system.timing import timePeriodSeconds, Timer
 
 class RateThrottle(object):
     """This object is used to provide rate throttling for activities.  It
@@ -42,13 +42,12 @@ class RateThrottle(object):
                 return
 
             self._curRate = 0
-            self._timeMark = datetime.now()
+            self._timeMark = Timer()
             self._goodMarks = 0
             return
 
         self._curRate += 1
-        newT = datetime.now()
-        deltaT = newT - self._timeMark
+        deltaT = self._timeMark.elapsed()
 
         if deltaT < timedelta(seconds=1):
             return

--- a/thespian/system/timing.py
+++ b/thespian/system/timing.py
@@ -80,7 +80,12 @@ class Timer(object):
 
 class ExpiryTime(object):
     def __init__(self, duration):
-        self._time_to_quit = None if duration is None else (currentTime() + duration)
+        if duration is None:
+            self._time_to_quit = None
+        elif isinstance(duration, timedelta):
+            self._time_to_quit = currentTime() + timePeriodSeconds(duration)
+        else:
+            self._time_to_quit = currentTime() + duration
     def expired(self):
         return False if self._time_to_quit is None else (currentTime() >= self._time_to_quit)
     def remaining(self, forever=None):

--- a/thespian/system/timing.py
+++ b/thespian/system/timing.py
@@ -97,19 +97,10 @@ class ExpirationTimer(object):
        May also be initialized with a duration of None, indicating
        that it should never timeout and that `remaining()` should
        return the forever value (defaulting to None).
-
-       Note that `timenow` is only provided for backwards compatibility. It is
-       completely ignored and will be removed soon.
     """
-    def __init__(self, duration=None, timenow=None):
+    def __init__(self, duration=None):
         self.duration = duration
         self._time_to_quit = None if duration is None else (currentTime() + duration)
-    def update_time_now(self, timenow):
-        """
-        This method only provided for backwards compatibility and is implemented
-        as noop. It will be removed soon.
-        """
-        pass
     def expired(self):
         "Returns true if the indicated duration has passed since this was created."
         return False if self._time_to_quit is None else (currentTime() >= self._time_to_quit)

--- a/thespian/system/timing.py
+++ b/thespian/system/timing.py
@@ -43,6 +43,41 @@ def toTimeDeltaOrNone(timespec):
     raise TypeError('Unknown type for timespec: %s'%type(timespec))
 
 
+class Timer(object):
+    """
+    Keeps track of the elapsed time since its creation or the last call to reset().
+    """
+    def __init__(self):
+        self._start = currentTime()
+    def elapsed(self):
+        """
+        :return: a timedelta object representing the elapsed time.
+        """
+        return timedelta(seconds=(currentTime() - self._start))
+    def elapsedSeconds(self):
+        """
+        :return: A float representing the elapsed time in seconds.
+        """
+        return timePeriodSeconds(self.elapsed())
+    def reset(self):
+        """
+        Restarts the timer.
+        """
+        self._start = currentTime()
+    def __str__(self):
+        return 'Started_on_' + str(self._start)
+    def __eq__(self, o):
+        return abs(self._start - o._start) < timedelta(microseconds=1)
+    def __lt__(self, o):
+        return self._start < o._start
+    def __gt__(self, o):
+        return not self.__lt__(o)
+    def __le__(self, o): return self.__eq__(o) or self.__lt__(o)
+    def __ge__(self, o): return self.__eq__(o) or self.__gt__(o)
+    def __ne__(self, o): return not self.__eq__(o)
+    def __nonzero__(self): return self.elapsedSeconds()
+
+
 class ExpiryTime(object):
     def __init__(self, duration):
         self._time_to_quit = None if duration is None else (currentTime() + duration)
@@ -100,7 +135,12 @@ class ExpirationTimer(object):
     """
     def __init__(self, duration=None):
         self.duration = duration
-        self._time_to_quit = None if duration is None else (currentTime() + duration)
+        if duration is None:
+            self._time_to_quit = None
+        elif isinstance(duration, timedelta):
+            self._time_to_quit = currentTime() + timePeriodSeconds(duration)
+        else:
+            self._time_to_quit = currentTime() + duration
     def expired(self):
         "Returns true if the indicated duration has passed since this was created."
         return False if self._time_to_quit is None else (currentTime() >= self._time_to_quit)

--- a/thespian/system/transport/MultiprocessQueueTransport.py
+++ b/thespian/system/transport/MultiprocessQueueTransport.py
@@ -50,7 +50,7 @@ testActorAdder.py:test07_LotsOfActorsEveryTenWithBackground (deadlocks
 import logging
 from thespian.actors import *
 from thespian.system.utilis import thesplog, partition, foldl, AssocList
-from thespian.system.timing import ExpiryTime, timePeriodSeconds
+from thespian.system.timing import timePeriodSeconds
 from thespian.system.transport import *
 from thespian.system.transport.asyncTransportBase import asyncTransportBase
 from thespian.system.transport.wakeupTransportBase import wakeupTransportBase

--- a/thespian/system/transport/UDPTransport.py
+++ b/thespian/system/transport/UDPTransport.py
@@ -17,7 +17,6 @@ even between processes on separate systems.
 
 import logging
 from thespian.system.utilis import thesplog
-from thespian.system.timing import ExpiryTime
 from thespian.actors import *
 from thespian.system.transport import *
 from thespian.system.transport.IPBase import *

--- a/thespian/system/transport/wakeupTransportBase.py
+++ b/thespian/system/transport/wakeupTransportBase.py
@@ -3,8 +3,7 @@ implements support for wakeupAfter() timed messages."""
 
 
 from thespian.actors import *
-from thespian.system.timing import ExpiryTime
-from datetime import datetime
+from thespian.system.timing import ExpirationTimer
 from thespian.system.transport import *
 
 
@@ -15,7 +14,7 @@ class wakeupTransportBase(object):
        functionality.
 
        This base mixin provides the primary .run() entrypoint for the
-       transport and a .run_time ExpiryTime member that provides the
+       transport and a .run_time ExpirationTime member that provides the
        remaining time-to-run period.
 
        The system can handle .wakeupAfter() requests by calling this
@@ -28,14 +27,14 @@ class wakeupTransportBase(object):
 
               Called by this class's .run() entrypoint to do the
               actual transport-specific run routine.  Should perform
-              that activity while the self.run_time ExpiryTime is not
+              that activity while the self.run_time ExpirationTimer is not
               expired (self.run_time will be updated when new
               wakeupAfter() events are scheduled).
     """
 
     def __init__(self, *args, **kw):
         super(wakeupTransportBase, self).__init__(*args, **kw)
-        # _pendingWakeups: key = datetime for wakeup, value = list of
+        # _pendingWakeups: key = ExpirationTimer for wakeup, value = list of
         # pending wakeupAfter msgs to restart at that time
         self._pendingWakeups = {}
         self._activeWakeups = []  # expired wakeups to be delivered
@@ -53,7 +52,7 @@ class wakeupTransportBase(object):
            idle to await new messages (or to do background
            processing).
         """
-        self._max_runtime = ExpiryTime(maximumDuration)
+        self._max_runtime = ExpirationTimer(maximumDuration)
 
         # Always make at least one pass through to handle expired wakeups
         # and queued events; otherwise a null/negative maximumDuration could
@@ -62,9 +61,7 @@ class wakeupTransportBase(object):
 
         while firstTime or not self._max_runtime.expired():
             firstTime = False
-            now = datetime.now()
-            self.run_time = min([ExpiryTime(P - now) for P in self._pendingWakeups] +
-                                [self._max_runtime])
+            self.run_time = min(list(self._pendingWakeups.keys()) + [self._max_runtime])
             rval = self._runWithExpiry(incomingHandler)
             if rval is not None:
                 return rval
@@ -85,20 +82,17 @@ class wakeupTransportBase(object):
 
 
     def addWakeup(self, timePeriod):
-        now = datetime.now()
-        wakeupTime = now + timePeriod
+        wakeupTime = ExpirationTimer(timePeriod)
         self._pendingWakeups.setdefault(wakeupTime, []) \
                             .append(ReceiveEnvelope(self.myAddress, WakeupMessage(timePeriod)))
-        self.run_time = min([ExpiryTime(P - now) for P in self._pendingWakeups] +
-                            [self._max_runtime])
+        self.run_time = min(list(self._pendingWakeups.keys()) + [self._max_runtime])
 
 
     def _realizeWakeups(self):
         "Find any expired wakeups and queue them to the send processing queue"
-        now = datetime.now()
         removals = []
         for wakeupTime in self._pendingWakeups:
-            if wakeupTime > now:
+            if not wakeupTime.expired():
                 continue
             self._activeWakeups.extend(self._pendingWakeups[wakeupTime])
             removals.append(wakeupTime)


### PR DESCRIPTION
This PR removes (almost) all usages of `datetime.now()` with an abstraction that uses `time.perf_timer()` in Python 3. It's crucial that the value returned by `time.perf_timer()` is only interpreted on the same physical system, i.e. the result of `time.perf_timer()` should never be sent via an actor message to another system and interpreted there. I checked all usages and it does not seem to be a problem here.

I am not sure about the semantics of `maxDelay == None` in `_drain_tx_queue_if_needed(self, max_delay=None)` (`asyncTransportBase`). To me it looks like this case did (A) not happen in practice and (B) if it did it cannot work. I interpreted that as an `ExpirationTimer` that will not time out.

I also noted `ExpiryTime` and `ExpirationTimer` are almost identical. Does it make sense to remove one of them from the code base?
