### PR TITLE
Fix local IP address determination

### DIFF
--- a/thespian/system/transport/IPBase.py
+++ b/thespian/system/transport/IPBase.py
@@ -103,9 +103,8 @@ class IPActorAddress(object):
            A "truthy" value of external can be an external address to
            try.  Using the address of the Convention Leader (if any)
            is recommended to ensure that the address chosen is
-           appropriate for the network supporting the Convention.  By
-           default, the address is Go Daddy's public webserver
-           address.
+           appropriate for the network supporting the Convention. By
+           default, the address is Google's public DNS server.
         """
         self.af = af
         self.socktype = socktype
@@ -114,13 +113,16 @@ class IPActorAddress(object):
             baseaddr = None
         if baseaddr == '':
             baseaddr = None if external else '127.0.0.1'
-        base2 = os.getenv('THESPIAN_BASE_IPADDR', None)
-        if base2:
+        if baseaddr is None and (base2 := os.getenv('THESPIAN_BASE_IPADDR', None)):
             baseaddr = base2
         if external and not baseaddr:
             # Trick to get the "public" IP address... doesn't work so
             # well if there are multiple routes, or if the public site
             # is not accessible.  (needs work)
+
+            # If external is a list, use just the first element
+            if isinstance(external, list):
+                external = external[0]
             remoteAddr = (
                 external
                 if isinstance(external, tuple)

--- a/thespian/system/transport/IPBase.py
+++ b/thespian/system/transport/IPBase.py
@@ -113,8 +113,8 @@ class IPActorAddress(object):
             baseaddr = None
         if baseaddr == '':
             baseaddr = None if external else '127.0.0.1'
-        if baseaddr is None and (base2 := os.getenv('THESPIAN_BASE_IPADDR', None)):
-            baseaddr = base2
+        if baseaddr is None:
+            baseaddr = os.getenv('THESPIAN_BASE_IPADDR', None)
         if external and not baseaddr:
             # Trick to get the "public" IP address... doesn't work so
             # well if there are multiple routes, or if the public site

--- a/thespian/system/transport/test/test_TCPAddresses.py
+++ b/thespian/system/transport/test/test_TCPAddresses.py
@@ -211,3 +211,19 @@ class TestUnitTCPAddresses(object):
         raises(TypeError, hash, a3)
         raises(TypeError, hash, a4)
         raises(TypeError, hash, a5)
+
+    def testThespianBaseAddressOverride(self, monkeypatch):
+        monkeypatch.setenv('THESPIAN_BASE_IPADDR', '1.2.3.4')
+
+        a1 = ActorAddress(TCPv4ActorAddress('1.2.3.4', 1234, external=False))
+        loopback = ActorAddress(TCPv4ActorAddress('127.0.0.1', 1234, external=False))
+
+        # override base address when None
+        assert a1 == ActorAddress(TCPv4ActorAddress(None, 1234, external=False))
+        assert a1 == ActorAddress(TCPv4ActorAddress(None, 1234, external=True))
+        # override base address when empty string
+        assert loopback == ActorAddress(TCPv4ActorAddress('', 1234, external=False))
+        assert a1 == ActorAddress(TCPv4ActorAddress('', 1234, external=True))
+        # do not ovverride base address when not None or empty string
+        assert a1 != ActorAddress(TCPv4ActorAddress('4.3.2.1', 1234, external=False))
+        assert a1 != ActorAddress(TCPv4ActorAddress('4.3.2.1', 1234, external=True))


### PR DESCRIPTION
Closes #86 

Tested with:
- [x] Functional tests on hosts with multiple interfaces, both with and without `THESPIAN_BASE_IPADDR` env var
- [x] `py.test` runs on Linux (Ubuntu 22.04, Python 3.11) and MacOS (Sequoia 15.3.1, Python 3.12)